### PR TITLE
Feat/answers enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Populate the settings as follows:
 
 - **algolia enabled**: Check this box to enable indexing new content with Algolia.
 - **algolia autocomplete enabled**: Check this box to replace the default Discourse autocomplete with the Algolia autocomplete. It is recommended to do this only once you have all content indexed (see below).
+- **algolia answers enabled**: Check this box to use [Algolia Answers](https://www.algolia.com/doc/guides/algolia-ai/answers/) to search Posts semantically.
 - **algolia application id**: The ID of an Algolia application you have created.
 - **algolia search api key**: A search-only API key of the Algolia application. Do not use an admin API key, as this will be visible to the clients of your Discourse.
 - **algolia admin api key**: The admin API key of your Discourse application, or any API key that can write and configure indices.

--- a/assets/javascripts/discourse/initializers/discourse-algolia.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-algolia.js.es6
@@ -30,6 +30,7 @@ export default {
               this._search = discourseAutocomplete._initialize({
                 algoliaApplicationId: this.siteSettings.algolia_application_id,
                 algoliaSearchApiKey: this.siteSettings.algolia_search_api_key,
+                algoliaAnswersEnabled: this.siteSettings.algolia_answers_enabled,
                 imageBaseURL: "",
                 debug: document.location.host.indexOf("localhost") > -1,
                 onSelect(event, suggestion) {

--- a/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
@@ -17,7 +17,7 @@ export default {
 
     // When Algolia Answers is enabled, use a different endpoint
     let postsSourceFallback = autocomplete.sources.hits(postsIndex, { hitsPerPage: hitsPerPage});
-    let postsSource = !options.algoliaAnswersEnabled? postSourceFallback:
+    let postsSource = !options.algoliaAnswersEnabled ? postsSourceFallback :
       function(query, callback) {
         const data = {
           "query": query,

--- a/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-autocomplete.js.es6
@@ -16,8 +16,8 @@ export default {
     let hitsPerPage = 4;
 
     // When Algolia Answers is enabled, use a different endpoint
-    let postsSource = !options.algoliaAnswersEnabled?
-      autocomplete.sources.hits(postsIndex, { hitsPerPage: hitsPerPage }) :
+    let postsSourceFallback = autocomplete.sources.hits(postsIndex, { hitsPerPage: hitsPerPage});
+    let postsSource = !options.algoliaAnswersEnabled? postSourceFallback:
       function(query, callback) {
         const data = {
           "query": query,
@@ -31,21 +31,27 @@ export default {
           method: "POST",
           headers: {
             "X-Algolia-Application-Id": options.algoliaApplicationId,
-            "X-Algolia-API-Key": options.algoliaSearchApiKey
+            "X-Algolia-API-Key": options.algoliaSearchApiKey + "XXX"
           },
           body: JSON.stringify(data)
         })
         .then((response) => response.json())
         .then((res) => {
-          res.hits.forEach(hit => {
-            console.log(hit);
-            if ("_answer" in hit && "extract" in hit["_answer"]) {
-              hit["_snippetResult"]["content"]["value"] = hit["_answer"]["extract"];
-            }
-          });
-          callback(res.hits);
+          if (!res.hits) {
+            throw new Error(`Invalid response: ${res.message}`);
+          } else {
+            res.hits.forEach(hit => {
+              if ("_answer" in hit && "extract" in hit["_answer"]) {
+                hit["_snippetResult"]["content"]["value"] = hit["_answer"]["extract"];
+              }
+            });
+            callback(res.hits);
+          }
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error("[Algolia Answers]", err);
+          return postsSourceFallback(query, callback);
+        });
     }
     return autocomplete(
       searchInput,

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,7 @@ en:
   site_settings:
     algolia_enabled: "Enable the discourse-algolia plugin and send data to Algolia for indexing"
     algolia_autocomplete_enabled: "Enable the Algolia autocomplete in the site header"
-    algolia_answers_enabled: "Use <a href='https://www.algolia.com/products/answers-for-publishers/'>Algolia Answers</a> when searching posts"
+    algolia_answers_enabled: "Use <a href='https://www.algolia.com/doc/guides/algolia-ai/answers/'>Algolia Answers</a> when searching posts"
     algolia_application_id: "The Algolia app ID where data should be sent for indexing"
     algolia_admin_api_key: "An Algolia API key with permissions to write data and configure indices"
     algolia_search_api_key: "An Algolia API key with <b>search</b> permission, used for the front end<br /><i>When Answers is enabled, it needs the </i><b>nluReadAnswers</b><i> permission too</i>"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,7 +2,8 @@ en:
   site_settings:
     algolia_enabled: "Enable the discourse-algolia plugin and send data to Algolia for indexing"
     algolia_autocomplete_enabled: "Enable the Algolia autocomplete in the site header"
+    algolia_answers_enabled: "Use <a href='https://www.algolia.com/products/answers-for-publishers/'>Algolia Answers</a> when searching posts"
     algolia_application_id: "The Algolia app ID where data should be sent for indexing"
     algolia_admin_api_key: "An Algolia API key with permissions to write data and configure indices"
-    algolia_search_api_key: "An Algolia API key with permission to search, used for the front end"
+    algolia_search_api_key: "An Algolia API key with <b>search</b> permission, used for the front end<br /><i>When Answers is enabled, it needs the </i><b>nluReadAnswers</b><i> permission too</i>"
     algolia_discourse_username: "The data indexed will contain only objects that this user can see"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,9 @@ plugins:
   algolia_autocomplete_enabled:
     default: false
     client: true
+  algolia_answers_enabled:
+    default: false
+    client: true
   algolia_application_id:
     default: ""
     client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,9 +2,9 @@
 
 # name: discourse-algolia
 # about: Use Algolia to power the search on your Discourse
-# version: 0.1
-# authors: Josh Dzielak and Gianluca Bargelli
-# url: https://github.com/algolia/discourse-algolia
+# version: 0.2
+# authors: Josh Dzielak and Gianluca Bargelli and Paul-Louis Nech
+# url: https://github.com/discourse/discourse-algolia
 
 gem 'httpclient', '2.8.3'
 gem 'algoliasearch', '1.26.0'


### PR DESCRIPTION
Before opening the PR on the [Discourse org](https://github.com/discourse) which now [owns our plugin](https://github.com/discourse/discourse-algolia), let's agree on the technical contribution here and on the PR's wording.

# Features
- [x] Added setting enabling Answers as a new option, defaulted to `false`
- [x] Updated instructions on API Key permissions for the `algoliaSearchApiKey`
- [x] Search for Posts using Answers when enabled, with fallback to the regular search
- [x] Updated readme and plugin metadata

# Implementation
- Took care to ensure Answers is optional
- To minimize changes to the front-end that could be frowned upon by current maintainers, I chose to [patch the hit's `_snippetResult.content.value`](url) with the Answers' `extract` when a hit has an Answer+extract. This allows the front-end to transparently handle both regular search and this Answers-enabled implementation.

# PR Content for `@discourse/discourse-algolia`

PR Title: **Allow using Algolia Answers for searching Posts**
_Everything below this line will be sent to the Discourse organisation in the PR description._

----

Hi there! We are releasing [a new API called Algolia Answers](https://www.algolia.com/products/answers-for-publishers/). This API allows to perform **semantic search** over textual content, returning relevant matches beyond textual relevance. 

![Screenshot of Algolia Answers](https://res.cloudinary.com/hilnmyskv/image/upload/q_auto/v1605531598/Algolia_com_Website_assets/images/answers-for-publishers/desktop_mobile_screens.png)

This PR **adds support for Algolia Answers** when searching Posts.

For example, a search for "Cleaning spammer registrations" could return the post [What about the spam problem](https://meta.discourse.org/t/what-about-the-spam-problem/2724).  The query's keywords are not present in the post, yet Answers finds a semantically relevant match within that post's content (`[...] Even with all of the usual anti-spam measures (e.g. blacklists, captchas, custom q & a questions on sign-up, CloudFlare), I still get hundreds of registrations a day that manually have to get cleaned out.`).

We've tested this new search experience on the data from [Algolia's Discourse](discourse.algolia.com), and found that it **improves the quality on 90% of the queries**, while the remaining 10% remain as good as with the regular search.

This PR includes:

- [x] Added setting enabling Answers as a new option, defaulted to `false`
- [x] Updated instructions on API Key permissions for the `algoliaSearchApiKey`
- [x] Search for Posts using Answers when enabled, with fallback to the regular search
- [x] Updated readme and plugin metadata

Here are some screenshots:
- ### Updated plugin settings
  ![Updated plugin settings](https://user-images.githubusercontent.com/1821404/99679335-1d405a00-2a7c-11eb-801a-d578bd0f1d30.png)


- ### Searching for posts, using the regular textual search
  ![image](https://user-images.githubusercontent.com/1821404/99679502-4c56cb80-2a7c-11eb-9833-bacdb20b9f03.png)

- ### Searching for posts, using Algolia Answers for semantic search
  _Notice how the most semantically relevant results are listed first, even if they have a lower textual relevance_
  ![image](https://user-images.githubusercontent.com/1821404/99679540-55e03380-2a7c-11eb-966d-802bb58d176d.png)

- ### Searching across Posts, Users and Tags, using semantic search for Posts
  ![image](https://user-images.githubusercontent.com/1821404/99684700-0b61b580-2a82-11eb-89d0-b0efd6c6d766.png)